### PR TITLE
Support adding JupyterHub server via URL handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     ],
     "activationEvents": [
         "onNotebook:jupyter-notebook",
-        "onNotebook:interactive"
+        "onNotebook:interactive",
+        "onUri"
     ],
     "main": "./dist/extension.node.js",
     "browser": "./dist/extension.web.js",

--- a/src/common/localize.ts
+++ b/src/common/localize.ts
@@ -44,4 +44,14 @@ export namespace Localized {
     export const emptyUserNameErrorMessage = l10n.t('Username cannot be empty');
     export const emptyPasswordErrorMessage = l10n.t('Password/API token cannot be empty');
     export const authMethodApiTokenMoreInfoTooltip = l10n.t('More Info');
+    export const invalidUriToAddServer = l10n.t('Invalid link, unable to add the JupyterHub server.');
+    export const addServerFromUriConfirm = (url: string) => l10n.t('Add the JupyterHub server {0}?', url);
+    export const addServerFromUriConfirmDetail = l10n.t(
+        'The link contains an API token that will be stored securely and used to connect to this server. Only continue if you trust the source of this link.'
+    );
+    export const addServerFromUriConfirmYes = l10n.t('Add Server');
+    export const addServerFromUriSuccess = (displayName: string) =>
+        l10n.t('Added the JupyterHub server {0}.', displayName);
+    export const addServerFromUriFailure = (url: string) =>
+        l10n.t('Failed to add the JupyterHub server {0}, please verify the URL, username and API token.', url);
 }

--- a/src/extension.node.ts
+++ b/src/extension.node.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ExtensionContext, ExtensionMode } from 'vscode';
+import { ExtensionContext, ExtensionMode, window } from 'vscode';
 import { disposableStore } from './common/lifecycle';
 import { JupyterHubUrlCapture } from './urlCapture';
+import { JupyterHubUriHandler } from './uriHandler';
 import { JupyterRequestCreator } from './common/requestCreator.node';
 import { traceError } from './common/logging';
 import { JupyterHubServerStorage } from './storage';
@@ -16,13 +17,19 @@ import { trackInstallOfExtension } from './common/telemetry';
 export async function activate(context: ExtensionContext) {
     trackInstallOfExtension();
     context.subscriptions.push(disposableStore);
+    // Register this synchronously, so that links opened while we're still activating are not lost.
+    const uriHandler = disposableStore.add(new JupyterHubUriHandler());
+    disposableStore.add(window.registerUriHandler(uriHandler));
     getJupyterApi()
         .then((api) => {
             const requestCreator = new JupyterRequestCreator();
             const fetch = new SimpleFetch(requestCreator);
             const storage = disposableStore.add(new JupyterHubServerStorage(context.secrets, context.globalState));
             const uriCapture = disposableStore.add(new JupyterHubUrlCapture(fetch, storage));
-            disposableStore.add(new JupyterServerIntegration(fetch, api.exports, storage, uriCapture));
+            const integration = disposableStore.add(
+                new JupyterServerIntegration(fetch, api.exports, storage, uriCapture)
+            );
+            uriHandler.initialize({ fetch, storage, urlCapture: uriCapture, integration });
         })
         .catch((ex) => traceError('Failed to activate jupyter extension', ex));
     if (context.extensionMode === ExtensionMode.Test) {

--- a/src/extension.web.ts
+++ b/src/extension.web.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ExtensionContext, ExtensionMode } from 'vscode';
+import { ExtensionContext, ExtensionMode, window } from 'vscode';
 import { disposableStore } from './common/lifecycle';
 import { JupyterHubUrlCapture } from './urlCapture';
+import { JupyterHubUriHandler } from './uriHandler';
 import { JupyterRequestCreator } from './common/requestCreator.web';
 import { traceError } from './common/logging';
 import { JupyterHubServerStorage } from './storage';
@@ -17,13 +18,19 @@ export async function activate(context: ExtensionContext) {
     trackInstallOfExtension();
     setIsWebExtension();
     context.subscriptions.push(disposableStore);
+    // Register this synchronously, so that links opened while we're still activating are not lost.
+    const uriHandler = disposableStore.add(new JupyterHubUriHandler());
+    disposableStore.add(window.registerUriHandler(uriHandler));
     getJupyterApi()
         .then((api) => {
             const requestCreator = new JupyterRequestCreator();
             const fetch = new SimpleFetch(requestCreator);
             const storage = disposableStore.add(new JupyterHubServerStorage(context.secrets, context.globalState));
             const uriCapture = disposableStore.add(new JupyterHubUrlCapture(fetch, storage));
-            disposableStore.add(new JupyterServerIntegration(fetch, api.exports, storage, uriCapture));
+            const integration = disposableStore.add(
+                new JupyterServerIntegration(fetch, api.exports, storage, uriCapture)
+            );
+            uriHandler.initialize({ fetch, storage, urlCapture: uriCapture, integration });
         })
         .catch((ex) => traceError('Failed to activate jupyter extension', ex));
 

--- a/src/jupyterIntegration.ts
+++ b/src/jupyterIntegration.ts
@@ -61,6 +61,9 @@ export class JupyterServerIntegration implements JupyterServerProvider, JupyterS
     public dispose() {
         dispose(this.disposables);
     }
+    public notifyServersChanged() {
+        this._onDidChangeServers.fire();
+    }
     public async handleCommand(
         command: JupyterServerCommand & { url?: string },
         token: CancellationToken

--- a/src/test/suite/uriHandler.test.ts
+++ b/src/test/suite/uriHandler.test.ts
@@ -1,0 +1,48 @@
+import { assert } from 'chai';
+import { Uri } from 'vscode';
+import { parseAddServerUri } from '../../uriHandler';
+
+describe('Uri Handler', function () {
+    const parse = (uri: string) => parseAddServerUri(Uri.parse(uri));
+
+    it('ignores unknown paths', function () {
+        assert.isUndefined(parse('vscode://ms-toolsai.jupyter-hub/something-else?url=https://hub.com'));
+    });
+    it('handles leading and trailing slashes in the path', function () {
+        assert.strictEqual(
+            parse('vscode://ms-toolsai.jupyter-hub/add-server/?url=https://hub.com')?.url,
+            'https://hub.com'
+        );
+    });
+    it('throws when the url is missing', function () {
+        assert.throws(() => parse('vscode://ms-toolsai.jupyter-hub/add-server'));
+    });
+    it('throws when the url is not http(s)', function () {
+        assert.throws(() => parse('vscode://ms-toolsai.jupyter-hub/add-server?url=ftp://hub.com'));
+        assert.throws(() => parse('vscode://ms-toolsai.jupyter-hub/add-server?url=not a url'));
+    });
+    it('parses all of the parameters', function () {
+        const request = parse(
+            'vscode://ms-toolsai.jupyter-hub/add-server?url=https://hub.com&username=bob&token=abc123&displayName=My%20Hub&serverName=gpu'
+        );
+        assert.deepStrictEqual(request, {
+            url: 'https://hub.com',
+            username: 'bob',
+            token: 'abc123',
+            displayName: 'My Hub',
+            serverName: 'gpu'
+        });
+    });
+    it('infers the username and token from the url', function () {
+        const request = parse('vscode://ms-toolsai.jupyter-hub/add-server?url=https://hub.com/user/bob/lab');
+        assert.strictEqual(request?.username, 'bob');
+        assert.strictEqual(request?.displayName, '');
+        assert.isUndefined(request?.serverName);
+    });
+    it('parameters take precedence over the values in the url', function () {
+        const request = parse(
+            'vscode://ms-toolsai.jupyter-hub/add-server?url=https://hub.com/user/bob/lab&username=alice'
+        );
+        assert.strictEqual(request?.username, 'alice');
+    });
+});

--- a/src/test/suite/urlCapture.test.ts
+++ b/src/test/suite/urlCapture.test.ts
@@ -1,0 +1,29 @@
+import { assert } from 'chai';
+import { getSuggestedDisplayName } from '../../urlCapture';
+
+describe('Suggested display name', function () {
+    it('uses the host name', function () {
+        assert.strictEqual(
+            getSuggestedDisplayName('https://jupyter.example.com/jh', undefined, []),
+            'jupyter.example.com'
+        );
+    });
+    it('includes the name of a named server', function () {
+        assert.strictEqual(
+            getSuggestedDisplayName('https://jupyter.example.com', 'gpu', []),
+            'jupyter.example.com (gpu)'
+        );
+    });
+    it('uses a generic name for ip addresses', function () {
+        assert.strictEqual(getSuggestedDisplayName('http://192.168.0.1:8000', undefined, []), 'JupyterHub');
+    });
+    it('does not use the reserved name localhost', function () {
+        assert.strictEqual(getSuggestedDisplayName('http://localhost:8000', undefined, []), 'localhost 1');
+    });
+    it('avoids names that are already in use', function () {
+        assert.strictEqual(
+            getSuggestedDisplayName('https://jupyter.example.com', undefined, ['jupyter.example.com']),
+            'jupyter.example.com 1'
+        );
+    });
+});

--- a/src/uriHandler.ts
+++ b/src/uriHandler.ts
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    CancellationError,
+    CancellationToken,
+    CancellationTokenSource,
+    ProgressLocation,
+    Uri,
+    UriHandler,
+    window
+} from 'vscode';
+import { Localized } from './common/localize';
+import { DisposableStore } from './common/lifecycle';
+import { traceDebug, traceError } from './common/logging';
+import { noop, uuid } from './common/utils';
+import { sendJupyterHubUrlAdded, sendJupyterHubUrlNotAdded } from './common/telemetry';
+import { SimpleFetch } from './common/request';
+import { JupyterHubServerStorage } from './storage';
+import { JupyterHubUrlCapture, getSuggestedDisplayName } from './urlCapture';
+import { JupyterServerIntegration } from './jupyterIntegration';
+import { Authenticator } from './authenticator';
+import { JupyterHubConnectionValidator } from './validator';
+import { extractTokenFromUrl, extractUserNameFromUrl, getJupyterHubBaseUrl, getVersion } from './jupyterHubApi';
+
+const AddServerPath = 'add-server';
+
+export type AddServerRequest = {
+    url: string;
+    username: string;
+    token: string;
+    displayName: string;
+    serverName: string | undefined;
+};
+
+/**
+ * Parses `vscode://ms-toolsai.jupyter-hub/add-server?url=...&username=...&token=...`.
+ *
+ * @returns Parsed parameters for valid `add-server` request, or `undefined` if the URI is not `add-server`
+ * @throws If the URI is `add-server` but is invalid
+ */
+export function parseAddServerUri(uri: Uri): AddServerRequest | undefined {
+    if (uri.path.replace(/^\/+|\/+$/g, '').toLowerCase() !== AddServerPath) {
+        return;
+    }
+    const query = new URLSearchParams(uri.query);
+    const url = (query.get('url') || '').trim();
+    if (!url || !isHttpUrl(url)) {
+        throw new Error(Localized.invalidUriToAddServer);
+    }
+    return {
+        url,
+        username: (query.get('username') || extractUserNameFromUrl(url) || '').trim(),
+        token: (query.get('token') || extractTokenFromUrl(url) || '').trim(),
+        displayName: (query.get('displayName') || '').trim(),
+        serverName: query.get('serverName') || undefined
+    };
+}
+
+function isHttpUrl(value: string) {
+    try {
+        return ['http:', 'https:'].includes(new URL(value).protocol.toLowerCase());
+    } catch (ex) {
+        traceDebug(`Failed to parse URL ${value}`, ex);
+        return false;
+    }
+}
+
+async function addServerFromUri(
+    request: AddServerRequest,
+    fetch: SimpleFetch,
+    storage: JupyterHubServerStorage,
+    cancelToken: CancellationToken
+): Promise<{ id: string; displayName: string }> {
+    const baseUrl = await getJupyterHubBaseUrl(request.url, fetch, cancelToken);
+    const hubVersion = await getVersion(baseUrl, fetch, cancelToken);
+    const authenticator = new Authenticator(fetch);
+    const authInfo = { username: request.username, password: '', token: request.token };
+    const result = await authenticator.getJupyterAuthInfo({ baseUrl, authInfo }, cancelToken);
+    await new JupyterHubConnectionValidator(fetch).validateJupyterUri(
+        baseUrl,
+        { ...authInfo, token: result.token },
+        authenticator,
+        cancelToken
+    );
+
+    const displayName =
+        request.displayName ||
+        getSuggestedDisplayName(
+            baseUrl,
+            request.serverName,
+            storage.all.map((s) => s.displayName)
+        );
+    const id = uuid();
+    await storage.addServerOrUpdate(
+        { id, baseUrl, displayName, serverName: request.serverName },
+        { username: request.username, password: '', token: result.token, tokenId: result.tokenId || '' }
+    );
+    sendJupyterHubUrlAdded(baseUrl, hubVersion, id);
+    return { id, displayName };
+}
+
+/**
+ * Handles `vscode://ms-toolsai.jupyter-hub/...` URIs.
+ *
+ * Implements a queue of pending URIs that are received before the extension is fully activated.
+ */
+export class JupyterHubUriHandler extends DisposableStore implements UriHandler {
+    private services?: {
+        fetch: SimpleFetch;
+        storage: JupyterHubServerStorage;
+        urlCapture: JupyterHubUrlCapture;
+        integration: JupyterServerIntegration;
+    };
+    private readonly pendingUris: Uri[] = [];
+
+    public initialize(services: {
+        fetch: SimpleFetch;
+        storage: JupyterHubServerStorage;
+        urlCapture: JupyterHubUrlCapture;
+        integration: JupyterServerIntegration;
+    }) {
+        this.services = services;
+        const pending = this.pendingUris.splice(0, this.pendingUris.length);
+        pending.forEach((uri) => this.handleUri(uri).then(noop, noop));
+    }
+
+    public async handleUri(uri: Uri): Promise<void> {
+        if (!this.services) {
+            traceDebug(`Queuing Uri ${uri.toString(true)} until the extension is fully activated`);
+            this.pendingUris.push(uri);
+            return;
+        }
+        const { fetch, storage, urlCapture, integration } = this.services;
+        let request: AddServerRequest | undefined;
+        try {
+            request = parseAddServerUri(uri);
+        } catch (ex) {
+            traceError(`Invalid Uri ${uri.toString(true)}`, ex);
+            window.showErrorMessage(Localized.invalidUriToAddServer).then(noop, noop);
+            return;
+        }
+        if (!request) {
+            traceError(`Unsupported Uri ${uri.toString(true)}`);
+            window.showErrorMessage(Localized.invalidUriToAddServer).then(noop, noop);
+            return;
+        }
+
+        if (!request.username || !request.token) {
+            const tokenSource = this.add(new CancellationTokenSource());
+            try {
+                const server = await urlCapture.captureRemoteJupyterUrl(
+                    tokenSource.token,
+                    request.url,
+                    request.displayName
+                );
+                if (server) {
+                    integration.notifyServersChanged();
+                }
+            } catch (ex) {
+                if (!(ex instanceof CancellationError)) {
+                    traceError(`Failed to add JupyterHub server ${request.url}`, ex);
+                }
+            }
+            return;
+        }
+
+        // The Uri carries a token, so nothing else would be displayed to the user.
+        // Confirm, as any web page can trigger such a link.
+        const yes = Localized.addServerFromUriConfirmYes;
+        const selection = await window.showInformationMessage(
+            Localized.addServerFromUriConfirm(request.url),
+            { modal: true, detail: Localized.addServerFromUriConfirmDetail },
+            yes
+        );
+        if (selection !== yes) {
+            sendJupyterHubUrlNotAdded('cancel', '');
+            return;
+        }
+
+        await window.withProgress(
+            { location: ProgressLocation.Notification, title: Localized.ConnectingToJupyterServer, cancellable: true },
+            async (_progress, cancelToken) => {
+                try {
+                    const { displayName } = await addServerFromUri(request!, fetch, storage, cancelToken);
+                    integration.notifyServersChanged();
+                    window.showInformationMessage(Localized.addServerFromUriSuccess(displayName)).then(noop, noop);
+                } catch (ex) {
+                    if (ex instanceof CancellationError) {
+                        sendJupyterHubUrlNotAdded('cancel', '');
+                        return;
+                    }
+                    traceError(`Failed to add JupyterHub server ${request!.url}`, ex);
+                    sendJupyterHubUrlNotAdded('error', '');
+                    window.showErrorMessage(Localized.addServerFromUriFailure(request!.url)).then(noop, noop);
+                }
+            }
+        );
+    }
+}

--- a/src/urlCapture.ts
+++ b/src/urlCapture.ts
@@ -501,8 +501,9 @@ export function getSuggestedDisplayName(baseUrl: string, serverName: string | un
     const usedNamesSet = new Set(usedNames.map((s) => s.toLowerCase()));
     usedNamesSet.add('localhost');
     usedNamesSet.add('');
-    const isIPAddress = typeof parseInt(new URL(baseUrl).hostname.charAt(0), 10) === 'number';
-    let hostName = isIPAddress ? 'JupyterHub' : new URL(baseUrl).hostname;
+    const hostNameOfUrl = new URL(baseUrl).hostname;
+    const isIPAddress = !isNaN(parseInt(hostNameOfUrl.charAt(0), 10));
+    let hostName = isIPAddress ? 'JupyterHub' : hostNameOfUrl;
     hostName = serverName ? `${hostName} (${serverName})` : hostName;
     if (!isIPAddress && !usedNamesSet.has(hostName.toLowerCase())) {
         return hostName;


### PR DESCRIPTION
URLs in the following format are supported:

```
vscode://ms-toolsai.jupyter-hub/add-server?url=<hub url>&username=<username>&token=<api token>&displayName=<label>&serverName=<named server>
```

If no credentials are supplied, the existing flow requesting username and password / API token is used.

* Also fixed the bug with generating suggested display names